### PR TITLE
Add example project

### DIFF
--- a/docs/app/_meta.js
+++ b/docs/app/_meta.js
@@ -1,5 +1,6 @@
 export default {
     index: 'Introduction',
     'getting-started': 'Getting Started',
+    'core-concepts': 'Core Concepts',
   }
   

--- a/docs/app/core-concepts/app-layer/page.md
+++ b/docs/app/core-concepts/app-layer/page.md
@@ -1,0 +1,57 @@
+# Application Layer (`/src/app`)
+
+The application layer represents the behavior and use cases of your system. It consumes domain models to create meaningful workflows, and is where your business logic lives.
+
+Unlike the domain layer (which defines what your system is), the app layer defines how your system behaves and interacts with users and services
+
+## Core Responsibilities
+
+- Compose features using domain models
+- Define custom routes and handlers (e.g. login, register, send flower)
+- Orchestrate service calls and enforce business logic
+- Handle authenticated user context (ctx.user) and side effects
+
+## App Layer is:
+- Imperative and executable
+- Feature- and use-case-driven
+- it's where your creativity and rules live
+
+This separation ensures the app layer remains flexible while keeping domain logic stable and declarative.
+
+The app layer contains your route and feature logic. Unlike the domain, this layer defines actual behavior and business use cases.
+
+
+## 📁 `app/`
+
+Top-level directory for route modules and domain-specific use cases.
+
+## 📁 `app/auth/`
+
+This folder contains routes related to authentication (e.g., login, register). Input is assumed to be validated by the framework based on the User domain model.
+
+```ts
+export const route = {
+  method: 'POST',
+  path: '/auth/login',
+  handler: async (ctx) => {
+    const body = await ctx.json();
+    // Business logic only
+    return ctx.json({ token: 'mock-token' });
+  }
+};
+```
+
+## 📁 `app/features/`
+
+This is where you define use-case-specific features that do not fit standard CRUD routes. These are more expressive and custom.
+
+export const route = {
+  method: 'POST',
+  path: '/flowers/give',
+  handler: async (ctx) => {
+    const body = await ctx.json();
+    const user = ctx.user;
+    // Handle business logic
+    return ctx.json({ message: 'Flower sent!' });
+  }
+};

--- a/docs/app/core-concepts/domain-layer/page.md
+++ b/docs/app/core-concepts/domain-layer/page.md
@@ -1,0 +1,39 @@
+# Domain Layer (`/src/domain`)
+
+The domain layer defines the core models of your application using plain TypeScript interfaces. These are the source of truth for your business entities.
+
+## Required*
+
+Each model must be defined as a TypeScript interface.
+
+## Optional Hooks
+
+Each domain model can export lifecycle hooks:
+
+```ts
+export const userHooks = {
+  beforeCreate: async (data) => {},
+  afterCreate: async (entity) => {},
+  // ...other hooks
+}
+```
+
+## Optional Configuration
+
+```ts
+export const flowerConfig = {
+  exposed: true,         // Whether to generate API routes, default true
+  authRequired: true     // Whether to wrap routes with auth middleware, default false
+}
+```
+
+## Relations
+
+You can reference other domain models directly:
+
+```ts
+export interface UserFlower {
+  user: User;           // Will be treated as `user_id` in DB
+  flower: Flower;       // Will be treated as `flower_id` in DB
+}
+```

--- a/docs/app/core-concepts/page.md
+++ b/docs/app/core-concepts/page.md
@@ -1,0 +1,19 @@
+# Philosophy
+Presha encourages clear separation of responsibilities by dividing the project into two main layers:
+
+## 🔹 Domain Layer (`/src/domain`)
+
+Defines the what: the structure of your business entities, their relationships, and rules. This layer is pure, declarative, and contains no runtime behavior.
+
+In presha.js, the domain layer can also drive API generation automatically. Based on your model:
+
+- A basic set of CRUD endpoints will be scaffolded.
+- Input/output will be validated using the model's structure.
+- Lifecycle hooks can intercept operations for validation, logging, or mutation.
+- Configuration can control visibility (exposed), protection (authRequired), and behavior.
+
+## 🔹 App Layer (`/src/app`)
+
+Defines the how: how the application uses those entities to fulfill specific business needs. This layer contains all the route handlers, feature logic, and orchestration.
+
+This distinction makes the project easier to reason about, more testable, and ideal for automation and generation.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,53 @@
+# 🧪 Examples
+
+This folder contains example projects built using **presha.js**.  
+
+These examples are used to validate framework functionality, guide development, and demonstrate real-world usage.
+
+---
+
+## 🎯 Project Goal
+
+The primary goal of the `examples/` folder is to drive the development of `presha.js` by building and iterating on a single reference project: `example-project`.
+
+`example-project` serves as the **cornerstone** of the framework — every feature in `presha.js` is validated against it.
+
+✅ The **first beta release** of `presha.js` will be considered complete once `example-project` runs successfully and demonstrates the core functionality of the framework.
+
+---
+
+## 📁 Current Structure
+
+```bash
+examples/
+└── example-project/     # The canonical app powered by presha.js
+```
+
+
+## 🛠 Usage
+Navigate into the example project:
+
+```bash
+cd examples/example-project
+npm i
+npm run dev
+```
+
+## 📚 Example Features (Planned)
+
+The example will gradually evolve to include:
+
+- 🛠 Route registration (GET /hello)
+- 🛠 Minimal runtime handler
+- 🛠 Input/output validation via Zod
+- 🛠 Type-safe domain modeling
+- 🛠 Automatic API docs
+- 🛠 SDK generation
+
+## 🧱 Architecture Principles
+- Minimal: no-boilerplate, readable structure
+- Modular: Clean separation between domain, app, and infrastructure
+- AI-friendly: Code is structured for ease of automation and generation
+- Scalable: Each piece of logic is testable and swappable
+
+> Stay focused on making example-project work — everything else builds from there.

--- a/examples/example-project/package.json
+++ b/examples/example-project/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "example-project",
+  "version": "1.0.0",
+  "description": "Cornerstone of presha.js framework development",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/examples/example-project/src/app/auth/login.ts
+++ b/examples/example-project/src/app/auth/login.ts
@@ -1,0 +1,23 @@
+import type { User } from '@/domain/user';
+
+/**
+ * Minimal login route.
+ * 
+ * Input is assumed to be validated against the User model.
+ */
+export const route = {
+  method: 'POST',
+  path: '/auth/login',
+
+  handler: async (ctx: any) => {
+    const body = await ctx.json() as Partial<User>;
+
+    // Business logic: fake login check
+    if (body.email === 'admin@example.com' && body.password === 'password123') {
+      return ctx.json({ token: 'mock-jwt-token' });
+    }
+
+    ctx.res.statusCode = 401;
+    return ctx.json({ error: 'Invalid credentials' });
+  }
+};

--- a/examples/example-project/src/app/auth/register.ts
+++ b/examples/example-project/src/app/auth/register.ts
@@ -1,0 +1,34 @@
+import type { User } from '@/domain/user';
+
+/**
+ * Minimal registration route.
+ * 
+ * Input is assumed to be pre-validated by the framework using the User domain model.
+ * The handler operates only on valid, typed data.
+ */
+export const route = {
+  method: 'POST',
+  path: '/auth/register',
+
+  handler: async (ctx: any) => {
+    const body = await ctx.json() as Partial<User>;
+
+    // Business logic: fake uniqueness check
+    const emailAlreadyExists = body.email === 'admin@example.com';
+    if (emailAlreadyExists) {
+      ctx.res.statusCode = 409;
+      return ctx.json({ error: 'Email already registered' });
+    }
+
+    // TODO: Save user to database (stubbed here)
+    const newUser: User = {
+      id: 'generated-id',
+      email: body.email!,
+      name: body.name ?? null,
+      createdAt: new Date(),
+      updatedAt: new Date()
+    };
+
+    return ctx.json(newUser);
+  }
+};

--- a/examples/example-project/src/app/features/give-flower/index.ts
+++ b/examples/example-project/src/app/features/give-flower/index.ts
@@ -1,0 +1,44 @@
+import type { User } from '@/domain/user';
+import type { Flower } from '@/domain/flower';
+
+/**
+ * Feature route: Give a flower to another user.
+ *
+ * - Input is pre-validated by the framework.
+ * - Current user is assumed to be available via `ctx.user`.
+ */
+export const route = {
+  method: 'POST',
+  path: '/flowers/give',
+
+  handler: async (ctx: any) => {
+    const body = await ctx.json() as {
+      toUserId: string;
+      flowerId: string;
+    };
+
+    const currentUser = ctx.user as User;
+
+    // Business logic (stub)
+    const flower: Flower = {
+      id: body.flowerId,
+      name: 'Rose',
+      price: 5,
+      available: true,
+      createdAt: new Date()
+    };
+
+    // TODO: Persist user-flower relation
+    const userFlower = {
+      id: 'new-user-flower-id',
+      user: currentUser,
+      flower,
+      favoritedAt: new Date()
+    };
+
+    return ctx.json({
+      message: `${currentUser.email} sent a ${flower.name} to user ${body.toUserId}`,
+      data: userFlower
+    });
+  }
+};

--- a/examples/example-project/src/domain/flower.ts
+++ b/examples/example-project/src/domain/flower.ts
@@ -1,0 +1,31 @@
+/**
+ * This interface defines the structure of the `Flower` entity.
+ *
+ * 🧩 This is a **required** domain model for presha.js code generation.
+ *
+ * The framework will generate:
+ * - Zod schema
+ * - CRUD routes (if `exposed: true`)
+ * - Repository/service/controller layers
+ *
+ * 📌 This model includes configuration flags instead of lifecycle hooks.
+ */
+export interface Flower {
+    id: string;
+    name: string;
+    price: number;
+    description?: string;
+    available: boolean;
+    createdAt: Date;
+  }
+
+/**
+   * Optional model-level configuration for the framework.
+   *
+   * - `exposed`: if false, the model is internal and no routes will be generated
+   * - `authRequired`: if true, routes will be protected by auth middleware
+   */
+export const config = {
+    exposed: true,
+    authRequired: true
+};

--- a/examples/example-project/src/domain/user.ts
+++ b/examples/example-project/src/domain/user.ts
@@ -1,0 +1,67 @@
+/**
+ * This interface defines the structure of the `User` entity.
+ *
+ * 🧩 This is a **required** part of the domain layer.
+ * The `presha.js` framework uses this interface as the source of truth to auto-generate:
+ * - Zod validation schemas
+ * - Database models (Prisma, Drizzle)
+ * - Repositories
+ * - Services
+ * - Controllers
+ * - Routes
+ *
+ * 🚨 Do not rename this interface or move it outside of the `domain/` folder,
+ * or it may not be picked up by the framework's parser.
+ */
+export interface User {
+    id: string;
+    email: string;
+    name?: string;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+/**
+ * Optional lifecycle hooks for the User model.
+ *
+ * These hooks allow you to insert logic before/after core actions like create, update, delete, or read.
+ * You can use them for validation, logging, authorization checks, etc.
+ *
+ * If omitted, the framework will simply skip hook execution.
+ */
+export const hooks = {
+    beforeCreate: async (data: Partial<User>) => {
+        if (!data.email?.includes('@')) {
+        throw new Error('Invalid email');
+        }
+        console.log('[User.beforeCreate]', data);
+    },
+
+    afterCreate: async (user: User) => {
+        console.log('[User.afterCreate]', user.id);
+    },
+
+    beforeUpdate: async (data: Partial<User>) => {
+        console.log('[User.beforeUpdate]', data);
+    },
+
+    afterUpdate: async (user: User) => {
+        console.log('[User.afterUpdate]', user.id);
+    },
+
+    beforeDelete: async (id: string) => {
+        console.log('[User.beforeDelete]', id);
+    },
+
+    afterDelete: async (id: string) => {
+        console.log('[User.afterDelete]', id);
+    },
+
+    beforeRead: async (id: string) => {
+        console.log('[User.beforeRead]', id);
+    },
+
+    afterRead: async (user: User | null) => {
+        console.log('[User.afterRead]', user?.id ?? 'not found');
+    }
+};

--- a/examples/example-project/src/domain/userFlower.ts
+++ b/examples/example-project/src/domain/userFlower.ts
@@ -1,0 +1,39 @@
+import type { User } from './user';
+import type { Flower } from './flower';
+
+/**
+ * This interface defines the structure of the `UserFlower` entity.
+ *
+ * It represents a many-to-many relationship between users and flowers,
+ * and includes full `User` and `Flower` references.
+ *
+ * 🔁 These references will be:
+ * - Represented in the **code** as typed objects (`User`, `Flower`)
+ * - Represented in the **database** as foreign keys:
+ *     - `user` ➝ `user_id` (FK to `users.id`)
+ *     - `flower` ➝ `flower_id` (FK to `flowers.id`)
+ *
+ * This approach enables:
+ * - Type-safe nested access in code
+ * - Proper foreign key mapping in DB
+ * - Easy generation of joins and includes in repositories/services
+ *
+ * 🧩 This model is not exposed via API routes (`exposed: false`)
+ */
+export interface UserFlower {
+  id: string;
+  user: User;
+  flower: Flower;
+  favoritedAt: Date;
+}
+
+/**
+ * Model configuration for `UserFlower`
+ *
+ * - `exposed: false` → skip route/controller generation
+ * - `authRequired: true` → usage assumes authenticated access
+ */
+export const userFlowerConfig = {
+  exposed: false,
+  authRequired: true
+};


### PR DESCRIPTION
## 📋 Summary

This PR establishes the foundation of the example-project, which serves as the canonical reference implementation for presha.js. It also includes the first iteration of framework documentation.

## 🔗 Related Issue(s)

<!-- List related issues (if any), e.g. closes #123 -->
Closes #

## 🧪 What’s Changed

- Created example-project with domain and app structure
- Defined User, Flower, and UserFlower models in the domain layer
- Added auth (login, register) and feature (give-flower) routes in the app layer
- Set up model-level configuration and lifecycle hooks
- Added Nextra-based documentation covering:
  - Philosophy of app vs domain layers
  - Domain model responsibilities and auto-generation
  - App layer routing and business logic composition



## ✅ Checklist

Please check all that apply:

- [ ] I have tested these changes locally
- [x] I have added or updated necessary documentation
- [ ] I have added appropriate tests (if applicable)
- [ ] I followed the coding standards and linting rules
- [x] I have added meaningful commit messages

## 📸 Screenshots / Demo (if UI-related)

<!-- If this PR includes UI changes, please add before/after screenshots or recordings -->

## 📝 Additional Context

This lays the groundwork for future features like:
- Auto-generating Zod schemas, routes, and services from domain
- Parsing domain metadata via ts-morph
- Pluggable validation and authorization layers

The first beta release will be gated on successfully running `example-project`.








